### PR TITLE
Added an option for one-line statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ conjunction with HERE documents can accomplish many things.  For example,
     puts("Hello, world!");
     HERE
 
+One Line Statements
+-------------------
+
+To run a one line statement, append a 1 (one) to the arg list along with m and
+use like:
+
+c99sh -ms1 'printf("hi, there\n");'
+
+Note that single quotes around the statement makes echo command to use the
+string in it as is, which helps.
+
 Control Files
 -------------
 

--- a/c99sh
+++ b/c99sh
@@ -30,6 +30,7 @@ Options:
   -t STMT  Append a main(argc, argv) implementation running statement STMT
   -v       Increase verbosity; may be supplied multiple times
   -x EXE   Save a successfully compiled executable as EXE instead of running it
+  -1	   1-line, put the line in main (provide -m as well) and run instead of providing a file/script
 
 An rcfile "${name}rc" controls compilation if present in the same directory as
 PROGRAM, or if present in the current working directory when processing standard
@@ -37,8 +38,8 @@ input.  Otherwise, if it exists, the file ~/.${name}rc controls compilation.
 
 If compilation is successful, the exit status is that of PROGRAM.
 "
-declare -i m=0 s=0 v=0
-while getopts hmp:r:st:vx: flag; do
+declare -i m=0 s=0 v=0 oneline=0
+while getopts hmp1:r:st:vx: flag; do
   case $flag in
     h) exec echo -ne "$help"      ;; # Stops processing due to exec
     m) m=1                        ;; # To be processed later
@@ -48,10 +49,13 @@ while getopts hmp:r:st:vx: flag; do
     t) T=$OPTARG;                 ;; # To be processed later; notice 'T' not 't'
     v) ((v+=1))                   ;; # Try -v, -vv, etc. to increase verbosity
     x) X=$OPTARG                  ;; # To be processed later; notice 'X' not 'x'
+    1) oneline=1		  ;; # To be processed while putting the code in
     ?) exit;                      ;;
   esac
 done
-shift $((OPTIND-1))
+shift $((OPTIND-2))
+statement=$1
+shift 1
 
 # Process standard input on absent or '-' filename otherwise snarf $1
 f="<stdin>"; d="."
@@ -156,7 +160,11 @@ emit_main_close() {
 #   (a) the source can be compiled without an unknown pragma warning, and
 #   (b) errors and warnings within the file show usable line information
 echo "#line 1 \"$f\""            >>"$c"
-sed "1s|^#!.*\$|#line 2 \"$f\"|" >>"$c"
+if [ $oneline -eq 1 ]; then
+	echo $statement >> "$c"
+else
+	sed "1s|^#!.*\$|#line 2 \"$f\"|" >>"$c"	
+fi
 
 # If requested, close main function about entire input
 [ $m -gt 0 ] && emit_main_close


### PR DESCRIPTION
This is what I wanted to do:
c99sh -ms1 'printf("hi\n");'

and I wasn't sure if it was already possible, so I added an option to the script. If it's already possible, maybe the README can be updated with an example, or if not maybe we can add it?

Motive: Why would you want to run a one-line statement? I haven't put it into action yet, but I believe it'll be useful in pipelining, for example possibly using c instead of sed or awk (if one has necessary libs/functions).

I wasn't sure if I should be updating any tests, and I'm not an expert on bash scripting, so hopefully I've done it right. And here it is.