### PR TITLE
1-liner: multiple -e statements should be saved as separate lines

### DIFF
--- a/basic/oneliner
+++ b/basic/oneliner
@@ -36,3 +36,6 @@ HERE
 
 # an example of escaping single-quotes on shell line:
 ../c99sh -e 'printf("'"'"'Hello ");' -e 'printf("World'"'"' ");' -e 'printf("from 1-liner\n");'
+
+# an example of escaping double-quotes
+../c99sh -e 'printf("\"Hello ");' -e 'printf("World\" ");' -e 'printf("from 1-liner\n");'

--- a/basic/oneliner
+++ b/basic/oneliner
@@ -39,3 +39,5 @@ HERE
 
 # an example of escaping double-quotes
 ../c99sh -e 'printf("\"Hello ");' -e 'printf("World\" ");' -e 'printf("from 1-liner\n");'
+
+../c99sh -e '#define w1 "Hello"' -e '#define w2 "World"' -e 'printf("%s %s\n", w1, w2);'

--- a/c99sh
+++ b/c99sh
@@ -163,7 +163,9 @@ emit_main_close() {
 echo "#line 1 \"$f\""            >>"$c"
 if [ $oneline -eq 1 ]
 then
-	echo ${stmts[@]} >> "$c"
+	for ((i = 0; i < $stmtcnt; ++i)); do
+		echo ${stmts[$i]} >> "$c"
+	done
 fi
 
 if [[ ($oneline -eq 1 && $m -gt 0) || $oneline -eq 0 ]]


### PR DESCRIPTION
Previous version didn't do it, becase the bash script loop I tried earlier separated every white space in the statement array and I had resorted to save the whole array in one echo. 

After encountering the problem on multiple statements with a #define (or // comment-line), I learned how to fix it with a proper loop.