### PR TITLE
Add -F and -L options

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,11 @@ The dual shebang/compiled approach was suggested by
 [jtsagata](http://github.com/jtsagata).  Thank you both for pushing on the
 idea, as I did not think it could be done in three clean lines.
 
-The one line execution similar to Perl's -e is done by
+The one line execution similar to Perl's -e was done by
 [mattapiroglu](http://github.com/mattapiroglu).
 
 The `-l` command line option was contributed by
 [flipcoder](https://github.com/flipcoder).
+
+The `-F` and `-L` command line options were contributed by
+[ProducerMatt](https://github.com/ProducerMatt).

--- a/basic/heredoc
+++ b/basic/heredoc
@@ -1,17 +1,8 @@
 #!/bin/bash -eux
-
 # C11 inside bash using a here document (in scripts skip the ../ prefix).
 ../c11sh -sm <<HERE
 #if __STDC_VERSION__ != 201112L
 #error C11 not detected
 #endif
 printf("Hello, world!\n");
-HERE
-
-# C99 requiring proper operation of -L for successful building
-../c99sh -vvv <<HERE
-#include <pthread.h>
-int main() {
-    pthread_exit(0L);
-}
 HERE

--- a/basic/heredoc
+++ b/basic/heredoc
@@ -1,8 +1,17 @@
-#!/bin/bash -eu
+#!/bin/bash -eux
+
 # C11 inside bash using a here document (in scripts skip the ../ prefix).
 ../c11sh -sm <<HERE
 #if __STDC_VERSION__ != 201112L
 #error C11 not detected
 #endif
 printf("Hello, world!\n");
+HERE
+
+# C99 requiring proper operation of -L for successful building
+../c99sh -vvv <<HERE
+#include <pthread.h>
+int main() {
+    pthread_exit(0L);
+}
 HERE

--- a/basic/oneliner
+++ b/basic/oneliner
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/bin/bash -eux
+set -o pipefail
 
 # Flag -e does not imply wrapping with main but does imply consuming some input
 ../c99sh -e 'int main() {}' </dev/null
@@ -12,6 +13,24 @@
 ../c99sh -ms </dev/null
 
 ../c99sh -mse 'printf("Hello from 1-liner\n");' </dev/null
+
+# Using -F causes the option to appear
+echo 'printf(MACRO);' | ../c99sh -ms '-FDMACRO="Salut\n"'
+
+# Further, using -F appends to CFLAGS
+(
+    export 'CFLAGS=-DANOTHER="Bonjour"'
+    echo 'printf(ANOTHER MACRO);' | ../c99sh -ms '-FDMACRO="Salut\n"'
+)
+
+# Using -L causes the option to appear thereby *breaking* this example
+! ../c99sh -mse 'printf("First test of -L\n");' -Llnonexistent </dev/null
+
+# Further, using -L appends to LDFLAGS thereby *breaking* this example
+(
+    export LDFLAGS=-lnonexistent
+    ! ../c99sh -mse 'printf("Third test of -L\n");' -Llm </dev/null
+)
 
 ../c99sh -mse 'int start = 3;' <<HERE
 return start == 3 ? 0 : 1;

--- a/c99sh
+++ b/c99sh
@@ -32,6 +32,8 @@ Options:
   -t STMT  Append a main(argc, argv) implementation running statement STMT
   -v       Increase verbosity; may be supplied multiple times
   -x EXE   Save a successfully compiled executable as EXE instead of running it
+  -F OPT   Add '-OPT' to \$CFLAGS when using \$CFLAGS during compilation
+  -L OPT   Add '-OPT' to \$LDFLAGS when using \$LDFLAGS during linking
 
 An rcfile '${name}rc' controls compilation if present in the same directory as
 PROGRAM, or if present in the current working directory when processing standard
@@ -41,18 +43,20 @@ If compilation is successful, the exit status is that of PROGRAM.
 "
 declare -i e=0 m=0 s=0 v=0 l=0
 declare -A E=() L=()
-while getopts e:hl:mp:r:st:vx: flag; do
+while getopts e:hl:mp:r:st:vx:F:L: flag; do
   case $flag in
-    e) E[$e]=$OPTARG; ((e+=1))    ;; # To be processed later; notice 'E' not 'e'
+    e) E[$e]=$OPTARG; ((e+=1))    ;; # To process later; notice 'E' not 'e'
     h) exec echo -ne "$help"      ;; # Stops processing due to exec
     l) L[$l]=$OPTARG; ((l+=1))    ;; # Libraries to be processed later
-    m) m=1                        ;; # To be processed later
+    m) m=1                        ;; # To process later
     p) pkg[$OPTARG]="flag -$flag" ;; # Additively record requested package
     r) r=$OPTARG                  ;; # Record requested rcfile, last one wins
-    s) s=1                        ;; # To be processed later
-    t) T=$OPTARG;                 ;; # To be processed later; notice 'T' not 't'
+    s) s=1                        ;; # To process later
+    t) T=$OPTARG;                 ;; # To process later; notice 'T' not 't'
     v) ((v+=1))                   ;; # Try -v, -vv, etc. to increase verbosity
-    x) X=$OPTARG                  ;; # To be processed later; notice 'X' not 'x'
+    x) X=$OPTARG                  ;; # To process later; notice 'X' not 'x'
+    F) CFLAGS="${CFLAGS:+${CFLAGS} }-$OPTARG"    ;; # Space-separated append
+    L) LDFLAGS="${LDFLAGS:+${LDFLAGS} }-$OPTARG" ;; # Space-separated append
     ?) exit;                      ;;
   esac
 done

--- a/cxx/heredoc
+++ b/cxx/heredoc
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/bash -eux
 # C++ inside bash using a here document (in scripts skip the ../ prefix).
 ../cxxsh -sm <<HERE
 cout << "Hello, world!" << endl;


### PR DESCRIPTION
This is an alternative to #36 that causes `-Ffoo` to act like `CFLAGS=-foo` and `-Lbar` to act like `LDFLAGS=-bar`.