### PR TITLE
Use portable shebang

### DIFF
--- a/basic/heredoc
+++ b/basic/heredoc
@@ -1,4 +1,5 @@
-#!/bin/bash -eux
+#!/usr/bin/env bash
+set -eux
 # C11 inside bash using a here document (in scripts skip the ../ prefix).
 ../c11sh -sm <<HERE
 #if __STDC_VERSION__ != 201112L

--- a/basic/oneliner
+++ b/basic/oneliner
@@ -1,4 +1,5 @@
-#!/bin/bash -eux
+#!/usr/bin/env bash
+set -eux
 set -o pipefail
 
 # Flag -e does not imply wrapping with main but does imply consuming some input

--- a/basic/tests
+++ b/basic/tests
@@ -1,4 +1,5 @@
-#!/bin/bash -eux
+#!/usr/bin/env bash
+set -eux
 # c99sh test driver relying upon c99shrc in the same directory
 cd "${0%/*}"
 

--- a/cxx/heredoc
+++ b/cxx/heredoc
@@ -1,4 +1,5 @@
-#!/bin/bash -eux
+#!/usr/bin/env bash
+set -eux
 # C++ inside bash using a here document (in scripts skip the ../ prefix).
 ../cxxsh -sm <<HERE
 cout << "Hello, world!" << endl;

--- a/cxx/tests
+++ b/cxx/tests
@@ -1,4 +1,5 @@
-#!/bin/bash -eux
+#!/usr/bin/env bash
+set -eux
 # cxxsh test driver relying upon cxxshrc in the same directory
 cd "${0%/*}"
 

--- a/gsl/tests
+++ b/gsl/tests
@@ -1,4 +1,5 @@
-#!/bin/bash -eux
+#!/usr/bin/env bash
+set -eux
 # c99sh test driver relying upon c99shrc in the same directory
 cd "${0%/*}"
 

--- a/openmp/tests
+++ b/openmp/tests
@@ -1,4 +1,5 @@
-#!/bin/bash -eux
+#!/usr/bin/env bash
+set -eux
 # c99sh test driver relying upon c99shrc in the same directory
 cd "${0%/*}"
 

--- a/tests
+++ b/tests
@@ -1,4 +1,5 @@
-#!/bin/bash -eux
+#!/usr/bin/env bash
+set -eux
 # c99sh top-level driver for all tests
 for driver in $(find . -mindepth 2 -name tests)
 do


### PR DESCRIPTION
This fixes errors when running `tests` on non-FHS compliant GNU/Linux distributions, such as NixOS and GNU Guix, where `/bin/bash` does not exist.