### PR TITLE
Fix stdin not being passed to compiled programs

### DIFF
--- a/basic/process_stdin
+++ b/basic/process_stdin
@@ -7,6 +7,8 @@ int main()
 {
     char name[100];
     int age;
+    const char *expected_name = "Alice";
+    const int expected_age = 30;
 
     // Read name from stdin
     if (fgets(name, sizeof(name), stdin) == NULL) {
@@ -23,8 +25,19 @@ int main()
         return 1;
     }
 
-    // Output the results
-    printf("Name: %s, Age: %d\n", name, age);
+    // Validate the data read matches expected values
+    if (strcmp(name, expected_name) != 0) {
+        fprintf(stderr, "Error: Expected name '%s' but got '%s'\n", expected_name, name);
+        return 1;
+    }
+
+    if (age != expected_age) {
+        fprintf(stderr, "Error: Expected age %d but got %d\n", expected_age, age);
+        return 1;
+    }
+
+    // Output success message
+    printf("stdin test passed: Name: %s, Age: %d\n", name, age);
     return 0;
 }
 // vim:syntax=c

--- a/basic/stdin_test
+++ b/basic/stdin_test
@@ -1,0 +1,30 @@
+#!../c99sh
+// Test that stdin is properly passed to the compiled program
+#include <stdio.h>
+#include <string.h>
+
+int main()
+{
+    char name[100];
+    int age;
+
+    // Read name from stdin
+    if (fgets(name, sizeof(name), stdin) == NULL) {
+        fprintf(stderr, "Failed to read name from stdin\n");
+        return 1;
+    }
+
+    // Remove newline if present
+    name[strcspn(name, "\n")] = 0;
+
+    // Read age from stdin
+    if (scanf("%d", &age) != 1) {
+        fprintf(stderr, "Failed to read age from stdin\n");
+        return 1;
+    }
+
+    // Output the results
+    printf("Name: %s, Age: %d\n", name, age);
+    return 0;
+}
+// vim:syntax=c

--- a/basic/tests
+++ b/basic/tests
@@ -9,6 +9,8 @@ cd "${0%/*}"
 
 ./heredoc
 
+# Test stdin handling - ensure stdin is properly passed to compiled program
+echo -e "Alice\n30" | ./stdin_test
 
 # Build
 rm -f ./a.out

--- a/basic/tests
+++ b/basic/tests
@@ -10,7 +10,7 @@ cd "${0%/*}"
 ./heredoc
 
 # Test stdin handling - ensure stdin is properly passed to compiled program
-echo -e "Alice\n30" | ./stdin_test
+echo -e "Alice\n30" | ./process_stdin
 
 # Build
 rm -f ./a.out

--- a/c99sh
+++ b/c99sh
@@ -71,7 +71,8 @@ if   [ $# -gt 0 ]
 then if   [ "$1" != "-" ]
      then f="$1"
           d=$(dirname "$1")
-          exec 0< "$1"
+          exec 3<&0          # Save original stdin to fd 3
+          exec 0< "$1"       # Redirect stdin to script file
      fi
      shift 1
 fi
@@ -176,6 +177,12 @@ done
 #   (b) errors and warnings within the file show usable line information
 echo "#line 1 \"$f\""            >>"$c"
 sed "1s|^#!.*\$|#line 2 \"$f\"|" >>"$c"
+
+# Restore original stdin if it was saved (i.e., when processing a file)
+if [ "$f" != "<stdin>" ]
+then exec 0<&3   # Restore stdin from fd 3
+     exec 3<&-   # Close fd 3
+fi
 
 # If requested, close main function about entire input
 [[ $m -gt 0 ]] && emit_main_close


### PR DESCRIPTION
When c99sh processes a script file, it redirects stdin to read from that
file. However, stdin was never restored after reading the script content.
This prevented the compiled program from reading user input from stdin.

The fix saves the original stdin to file descriptor 3 before redirecting
stdin to the script file, then restores stdin from fd 3 after the script
content has been fully read by the sed command.

Fixes #42