### PR TITLE
Refresh Circle-CI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,21 +3,22 @@ version: 2.1
 
 jobs:
   "Test":
+    resource_class: small
     docker:
-      - image: "cimg/base:2021.04"
+      - image: "cimg/base:2024.09"
     steps:
       - checkout
       - run:
           name: Install dependencies
           command: |
             sudo apt-get update
-            sudo apt-get install -y libgsl0-dev
+            sudo apt-get install -y libgsl-dev
             sudo apt-get install -y autotools-dev
-            sudo apt-get install -y g++-10
+            sudo apt-get install -y gcc g++
       - run:
           name: Test c99sh
           command: |
-            COMPILER_NAME=gcc CXX=g++-10 CC=gcc-10 ./tests
+            COMPILER_NAME=gcc CXX=g++ CC=gcc ./tests
 
 workflows:
   build:


### PR DESCRIPTION
- Upgrade base image from 2021.04 to 2024.09
- Update libgsl0-dev to libgsl-dev for newer Ubuntu versions
- Use default gcc/g++ instead of version-specific compilers
- Add small resource_class for cost optimization